### PR TITLE
Use new same-object

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "error-stack-parser": "^2.1.4",
     "glob": "^8.0.3",
     "minimist": "^1.2.6",
-    "same-object": "^1.0.0",
+    "same-object": "github:holepunchto/same-object#rewrite",
     "tmatch": "^5.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "error-stack-parser": "^2.1.4",
     "glob": "^8.0.3",
     "minimist": "^1.2.6",
-    "same-object": "github:holepunchto/same-object#rewrite",
+    "same-object": "^1.0.2",
     "tmatch": "^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This `same-object` patch version contains all new code with zero deps, and it's backwards compatible

Due semver we don't really need the upgrade, but still good to formally make this PR