### PR TITLE
Use AssertionErrors to avoid errors getting safety-caught

### DIFF
--- a/index.js
+++ b/index.js
@@ -320,7 +320,7 @@ class Test {
 
   _plan (n) {
     if (typeof n !== 'number' || n < 0) {
-      throw new AssertionError({ message: 'Plan takes a positive whole number only' })
+      throw new Error('Plan takes a positive whole number only')
     }
 
     this._hasPlan = true
@@ -328,7 +328,7 @@ class Test {
   }
 
   _comment (...m) {
-    if (this.isResolved) throw new AssertionError({ message: 'Can\'t comment after end' })
+    if (this.isResolved) throw new Error('Can\'t comment after end')
     this.runner.log(INDENT + '#', ...m)
   }
 
@@ -439,7 +439,7 @@ class Test {
   }
 
   _teardown (fn, opts) {
-    if (this.isDone) throw new AssertionError({ message: 'Can\'t add teardown after end' })
+    if (this.isDone) throw new Error('Can\'t add teardown after end')
     this._teardowns.push([(opts && opts.order) || 0, fn])
   }
 
@@ -654,7 +654,7 @@ class Test {
 
     if (this.isMain) {
       if (!this.isQueued) {
-        if (this.runner.next) throw new AssertionError({ message: 'Only run test can be running at the same time' })
+        if (this.runner.next) throw new Error('Only run test can be running at the same time')
         this.runner.next = this
       }
       this.header()
@@ -706,7 +706,7 @@ function configure ({ timeout = DEFAULT_TIMEOUT, bail = false, solo = false, sou
   const runner = getRunner()
 
   if (runner.tests.count > 0 || runner.assertions.count > 0) {
-    throw new AssertionError({ message: 'Configuration must happen prior to registering any tests' })
+    throw new Error('Configuration must happen prior to registering any tests')
   }
 
   runner.defaultTimeout = timeout
@@ -751,7 +751,7 @@ function test (name, opts, fn, defaults) {
   if (t.isTodo) return t._run(() => {}, opts)
 
   if (t.isSkip) {
-    throw new AssertionError({ message: 'An inverted test cannot be skipped' })
+    throw new Error('An inverted test cannot be skipped')
   }
   if (t.isSolo) {
     t.runner.solo = t

--- a/index.js
+++ b/index.js
@@ -2,10 +2,7 @@ const sameObject = require('same-object')
 const b4a = require('b4a')
 const { getSnapshot, createTypedArray } = require('./lib/snapshot')
 const { INDENT, RUNNER, IS_NODE, DEFAULT_TIMEOUT } = require('./lib/constants')
-
-const assert = requireIfNode('assert')
-const AssertionError = assert ? assert.AssertionError : Error // TODO: what to do for browser? Will still be ignored by safetycatch
-
+const AssertionError = require('./lib/assertion-error')
 const highDefTimer = IS_NODE ? highDefTimerNode : highDefTimerFallback
 
 // loaded on demand since it's error flow and we want ultra fast positive test runs
@@ -846,12 +843,4 @@ function prematureEnd (t, message) {
     : ''
 
   return new Error(message + details)
-}
-
-function requireIfNode (name) {
-  try {
-    return IS_NODE ? require(name) : null
-  } catch {
-    return null
-  }
 }

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const b4a = require('b4a')
 const { getSnapshot, createTypedArray } = require('./lib/snapshot')
 const { INDENT, RUNNER, IS_NODE, DEFAULT_TIMEOUT } = require('./lib/constants')
 const AssertionError = require('./lib/assertion-error')
+
 const highDefTimer = IS_NODE ? highDefTimerNode : highDefTimerFallback
 
 // loaded on demand since it's error flow and we want ultra fast positive test runs

--- a/lib/assertion-error.js
+++ b/lib/assertion-error.js
@@ -1,21 +1,12 @@
-const { IS_NODE } = require('./constants')
-const assert = requireIfNode('assert')
+const CODE = 'ERR_ASSERTION'
 
-class CustomAssertionError extends Error {
+module.exports = class AssertionError extends Error {
   constructor ({ message }) {
-    super(message)
-    this.code = 'ERR_ASSERTION'
-    this.name = 'AssertionError'
+    super(`${CODE}: ${message}`)
+    this.code = CODE
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, AssertionError)
+    }
   }
 }
-
-function requireIfNode (name) {
-  try {
-    return IS_NODE ? require(name) : null
-  } catch {
-    return null
-  }
-}
-
-const AssertionError = assert ? assert.AssertionError : CustomAssertionError
-module.exports = AssertionError

--- a/lib/assertion-error.js
+++ b/lib/assertion-error.js
@@ -1,0 +1,21 @@
+const { IS_NODE } = require('./constants')
+const assert = requireIfNode('assert')
+
+class CustomAssertionError extends Error {
+  constructor ({ message }) {
+    super(message)
+    this.code = 'ERR_ASSERTION'
+    this.name = 'AssertionError'
+  }
+}
+
+function requireIfNode (name) {
+  try {
+    return IS_NODE ? require(name) : null
+  } catch {
+    return null
+  }
+}
+
+const AssertionError = assert ? assert.AssertionError : CustomAssertionError
+module.exports = AssertionError

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "chalk": "^4.1.2",
+    "safety-catch": "^1.0.2",
     "standard": "^17.0.0"
   },
   "repository": {


### PR DESCRIPTION
The added test illustrates the relevance, with a case where a normal 'Assertion after end' error gets swallowed and the test passes even though it should fail (fixed with this PR)

Note: this will not work for browser code, as when `assert` does not exist, normal errors will still be thrown. I indicated this with a TODO, as that was already broken beforehand and this PR at least fixes the Node case.