### PR TITLE
Support Bare

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const sameObject = require('same-object')
 const b4a = require('b4a')
 const { getSnapshot, createTypedArray } = require('./lib/snapshot')
-const { INDENT, RUNNER, IS_NODE, DEFAULT_TIMEOUT } = require('./lib/constants')
+const { INDENT, RUNNER, IS_NODE, IS_BARE, DEFAULT_TIMEOUT } = require('./lib/constants')
 const AssertionError = require('./lib/assertion-error')
 
 const highDefTimer = IS_NODE ? highDefTimerNode : highDefTimerFallback
@@ -41,6 +41,7 @@ class Runner {
     this._resume = null
 
     if (IS_NODE) process.once('beforeExit', () => this.end())
+    if (IS_BARE) Bare.once('beforeExit', () => this.end())
   }
 
   resume () {

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ class Runner {
     this._resume = null
 
     if (IS_NODE) process.once('beforeExit', () => this.end())
-    if (IS_BARE) Bare.once('beforeExit', () => this.end())
+    if (IS_BARE) global.Bare.once('beforeExit', () => this.end())
   }
 
   resume () {

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ class Runner {
       this.next = test
       test.header()
 
-      if (!IS_NODE) this._autoExit(test)
+      if (!IS_NODE && !IS_BARE) this._autoExit(test)
 
       return true
     }
@@ -188,6 +188,7 @@ class Runner {
       this.log(ind + 'ok ' + number, message)
     } else {
       if (IS_NODE) process.exitCode = 1
+      if (IS_BARE) global.Bare.exitCode = 1
       this.log(ind + 'not ok ' + number, message)
       if (explanation) this.log(lazy.errors.stringify(explanation))
       if (this.bail && !this.skipAll) this.skipAll = true

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,5 +1,5 @@
 exports.INDENT = '    '
 exports.RUNNER = Symbol.for('brittle-runner')
 exports.IS_NODE = !!(typeof process === 'object' && process && process.versions && (typeof (process.versions.node || process.versions.pear || process.versions.bare) === 'string') && !process.browser)
-exports.IS_BARE = !!global.Bare
+exports.IS_BARE = typeof Bare !== 'undefined'
 exports.DEFAULT_TIMEOUT = 30000

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,4 +1,5 @@
 exports.INDENT = '    '
 exports.RUNNER = Symbol.for('brittle-runner')
 exports.IS_NODE = !!(typeof process === 'object' && process && process.versions && (typeof (process.versions.node || process.versions.pear || process.versions.bare) === 'string') && !process.browser)
+exports.IS_BARE = !!global.Bare
 exports.DEFAULT_TIMEOUT = 30000

--- a/package.json
+++ b/package.json
@@ -27,10 +27,15 @@
     "tmatch": "^5.0.0"
   },
   "devDependencies": {
-    "bare-subprocess": "^2.0.2",
+    "bare-subprocess": "^2.0.3",
     "chalk": "^4.1.2",
     "safety-catch": "^1.0.2",
     "standard": "^17.0.0"
+  },
+  "imports": {
+    "child_process": {
+      "bare": "bare-subprocess"
+    }
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "author": "David Mark Clements (@davidmarkclem)",
   "license": "Apache-2.0",
   "scripts": {
-    "test": "standard && node test/all.mjs"
+    "test": "standard && node test/all.mjs",
+    "test-bare": "bare test/bare-test.mjs"
   },
   "files": [
     "index.js",
@@ -26,6 +27,7 @@
     "tmatch": "^5.0.0"
   },
   "devDependencies": {
+    "bare-subprocess": "^2.0.2",
     "chalk": "^4.1.2",
     "safety-catch": "^1.0.2",
     "standard": "^17.0.0"

--- a/test/bare-test.mjs
+++ b/test/bare-test.mjs
@@ -43,7 +43,7 @@ function redBold (str) {
 }
 
 // This is a modified version of executeCode() in test/helpers/index.js to support `bare.
-// The reason is that `bare` does not support passing code as a commandline argument.
+// The reason is that the passed code to `bare --eval` does not seem able to require modules from relative paths
 async function executeCode (scriptPath) {
   return new Promise((resolve, reject) => {
     const child = spawn(runtime, [scriptPath])

--- a/test/bare-test.mjs
+++ b/test/bare-test.mjs
@@ -3,20 +3,23 @@ import { IS_BARE } from '../lib/constants.js'
 
 let runtime
 let spawn
-if (IS_BARE) {
-  const subprocess = await import('bare-subprocess')
-  runtime = 'bare'
-  spawn = subprocess.spawn
-} else {
-  const cp = await import('child_process')
-  runtime = 'node'
-  spawn = cp.spawn
-}
+
+test('setup', async t => {
+  if (IS_BARE) {
+    const subprocess = await import('bare-subprocess')
+    runtime = 'bare'
+    spawn = subprocess.spawn
+  } else {
+    const cp = await import('child_process')
+    runtime = 'node'
+    spawn = cp.spawn
+  }
+})
 
 test('running bare script fails as intended', async t => {
   t.plan(4)
   const { exitCode, error, stdout, stderr } = await executeCode('./test/helpers/bare-test-script.js')
-  t.is(exitCode, 0) // 1 for 'node, 0 for 'bare'
+  t.is(exitCode, 1) // 1 for 'node, 0 for 'bare'
   t.absent(error)
   t.ok(stderr.includes('assertion count (0) did not reach plan (1)'))
   t.ok(stdout.includes('test should fail')) // Name of the test, stored in ./helpers/bare-test-script.js

--- a/test/bare-test.mjs
+++ b/test/bare-test.mjs
@@ -1,45 +1,45 @@
 import { IS_BARE, IS_NODE } from '../lib/constants.js'
 import { spawn } from 'child_process'
 
-const chalk = !IS_BARE && import('chalk').then(m => m.default)
+const chalk = !IS_BARE && await import('chalk').then(m => m.default)
 const runtime = IS_BARE ? 'bare' : 'node'
 
 let didTestError = false
 
 const { exitCode, error, stdout, stderr } = await executeCode('./test/helpers/bare-test-script.js')
-if (!is(IS_BARE ? 0 : 1, exitCode)) await fnError('wrong exitcode', IS_BARE ? 0 : 1, exitCode)
-if (!absent(error)) await fnError('error is there')
-if (!ok(stderr.includes('assertion count (0) did not reach plan (1)'))) await fnError('should include assertion count')
-if (!ok(stdout.includes('test should fail'))) await fnError('wrong test name') // Name of the test, stored in ./helpers/bare-test-script.js
+if (!is(IS_BARE ? 0 : 1, exitCode)) fnError('wrong exitcode', IS_BARE ? 0 : 1, exitCode)
+if (!absent(error)) fnError('error is there')
+if (!ok(stderr.includes('assertion count (0) did not reach plan (1)'))) fnError('should include assertion count')
+if (!ok(stdout.includes('test should fail'))) fnError('wrong test name') // Name of the test, stored in ./helpers/bare-test-script.js
 
 if (didTestError) {
   if (IS_BARE) global.Bare.exitCode = 1
   if (IS_NODE) process.exitCode = 1
 }
 
-async function fnError (err, expected, actual) {
+function fnError (err, expected, actual) {
   didTestError = true
 
-  console.error(await redBold('Error:'), err)
+  console.error(redBold('Error:'), err)
 
   if (actual || expected) {
-    console.error(await red('[actual]'))
+    console.error(red('[actual]'))
     console.error(actual)
-    console.error(await red('[expected'))
+    console.error(red('[expected'))
     console.error(expected)
   }
 }
 
-async function red (str) {
+function red (str) {
   return IS_BARE
     ? str
-    : (await chalk).red(str)
+    : chalk.red(str)
 }
 
-async function redBold (str) {
+function redBold (str) {
   return IS_BARE
     ? str
-    : (await chalk).red.bold(str)
+    : chalk.red.bold(str)
 }
 
 // This is a modified version of executeCode() in test/helpers/index.js to support `bare.

--- a/test/bare-test.mjs
+++ b/test/bare-test.mjs
@@ -1,0 +1,53 @@
+import test from '../index.js'
+import { IS_BARE } from '../lib/constants.js'
+
+let runtime
+let spawn
+if (IS_BARE) {
+  const subprocess = await import('bare-subprocess')
+  runtime = 'bare'
+  spawn = subprocess.spawn
+} else {
+  const cp = await import('child_process')
+  runtime = 'node'
+  spawn = cp.spawn
+}
+
+test('running bare script fails as intended', async t => {
+  t.plan(4)
+  const { exitCode, error, stdout, stderr } = await executeCode('./test/helpers/bare-test-script.js')
+  t.is(exitCode, 0) // 1 for 'node, 0 for 'bare'
+  t.absent(error)
+  t.ok(stderr.includes('assertion count (0) did not reach plan (1)'))
+  t.ok(stdout.includes('test should fail')) // Name of the test, stored in ./helpers/bare-test-script.js
+})
+
+async function executeCode (scriptPath) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(runtime, [scriptPath])
+
+    let exitCode
+    let stdout = ''
+    let stderr = ''
+
+    child.on('exit', function (code) {
+      exitCode = code
+      resolve({ exitCode, stdout, stderr })
+    })
+
+    child.on('close', function () {
+      resolve({ exitCode, stdout, stderr })
+    })
+
+    child.on('error', function (error) {
+      resolve({ exitCode, error, stdout, stderr })
+    })
+
+    child.stdout.on('data', function (chunk) {
+      stdout += chunk.toString()
+    })
+    child.stderr.on('data', function (chunk) {
+      stderr += chunk.toString()
+    })
+  })
+}

--- a/test/helpers/bare-test-script.js
+++ b/test/helpers/bare-test-script.js
@@ -1,5 +1,6 @@
 // This script is used as a test case with the `bare` runtime.
-// It is stored as a file, instead of generated, because `bare` does not take code as an argument
+// It is stored as a file, instead of generated, because the passed code to
+// `bare --eval` does not seem able to require modules from relative paths
 const test = require('../../index.js')
 
 const _fn = t => t.plan(1)

--- a/test/helpers/bare-test-script.js
+++ b/test/helpers/bare-test-script.js
@@ -1,0 +1,7 @@
+// This script is used as a test case with the `bare` runtime.
+// It is stored as a file, instead of generated, because `bare` does not take code as an argument
+const test = require('../../index.js')
+
+const _fn = t => t.plan(1)
+
+test('test should fail', _fn)


### PR DESCRIPTION
Enable support for `Bare`.

When running the test case, `test/bare-test.mjs` in `node` it will still output as expected from the other tests.
![image](https://github.com/holepunchto/brittle/assets/376654/7f2b055d-d2ba-474c-b14a-51c3e4f4ff24)
