### PR TITLE
Error if no test files were specified, if a file does not exist, or if a glob resolves to nothing

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -89,6 +89,10 @@ async function start () {
 
   brittle.pause()
 
+  if (files.length === 0) {
+    throw new Error('No test files were specified')
+  }
+
   for (const f of files) {
     await import('file://' + path.resolve(f))
   }

--- a/cmd.js
+++ b/cmd.js
@@ -17,7 +17,15 @@ const argv = minimist(args, {
 })
 
 const files = []
-for (const g of argv._) files.push(...glob.sync(g))
+for (const g of argv._) {
+  const matches = glob.sync(g)
+  if (matches.length === 0) {
+    console.error(`Error: no files found when resolving ${g}`)
+    process.exit(1)
+  }
+
+  files.push(...matches)
+}
 
 if (files.length === 0) {
   console.error('Error: No test files were specified')

--- a/cmd.js
+++ b/cmd.js
@@ -19,6 +19,11 @@ const argv = minimist(args, {
 const files = []
 for (const g of argv._) files.push(...glob.sync(g))
 
+if (files.length === 0) {
+  console.error('Error: No test files were specified')
+  process.exit(1)
+}
+
 const { solo, bail, cov } = argv
 
 process.title = 'brittle'
@@ -88,10 +93,6 @@ async function start () {
   }
 
   brittle.pause()
-
-  if (files.length === 0) {
-    throw new Error('No test files were specified')
-  }
 
   for (const f of files) {
     await import('file://' + path.resolve(f))


### PR DESCRIPTION
Edit: scope of PR get extended, see discussion below

Previous behaviour is to report a success:
```
# tests = 0/0 pass
# asserts = 0/0 pass
# time = 3.067152ms

# ok
```

Behaviour of this PR is to log
```
Error: No test files were specified
```
and to exit with 1 status code

