### PR TITLE
Fail when no assertions

### DIFF
--- a/index.js
+++ b/index.js
@@ -679,7 +679,7 @@ class Test {
       const testPassed = ok && this.assertions > 0
       const explanation = this.assertions > 0
         ? null
-        : 'No assertions were tested'
+        : 'No assertions were called'
 
       const time = this._timer ? ' # time = ' + this._timer() + 'ms' : ''
 

--- a/index.js
+++ b/index.js
@@ -177,8 +177,9 @@ class Runner {
     this.log('# time = ' + this._timer() + 'ms')
     this.log()
 
-    if (this.tests.count === this.tests.pass && this.assertions.count === this.assertions.pass) this.log('# ok')
-    else this.log('# not ok')
+    if (this.assertions.count === 0) {
+      throw new Error('No assertions were tested during the run')
+    }
   }
 
   assert (indent, ok, number, message, explanation) {

--- a/index.js
+++ b/index.js
@@ -675,8 +675,14 @@ class Test {
     const ok = (this.fails === 0)
 
     if (this.isMain && !err) {
+      const testPassed = ok && this.assertions > 0
+      const explanation = this.assertions > 0
+        ? null
+        : 'No assertions were tested'
+
       const time = this._timer ? ' # time = ' + this._timer() + 'ms' : ''
-      this.runner.assert(false, ok, this._track(true, ok), '- ' + (this.name || '') + time, null)
+
+      this.runner.assert(false, testPassed, this._track(true, ok), '- ' + (this.name || '') + time, explanation)
     }
 
     this.isResolved = true

--- a/index.js
+++ b/index.js
@@ -177,8 +177,8 @@ class Runner {
     this.log('# time = ' + this._timer() + 'ms')
     this.log()
 
-    if (this.assertions.count === 0) {
-      throw new Error('No assertions were tested during the run')
+    if (this.tests.count === 0) {
+      throw new Error('No tests were defined during the run')
     }
   }
 

--- a/test/fail-when-no-assertions.mjs
+++ b/test/fail-when-no-assertions.mjs
@@ -18,5 +18,8 @@ not ok 1 - fails on a test without any assertions # time = 1.300587ms
 # time = 17.131802ms
 
 # not ok  `,
-  { exitCode: 1, stderr: '' }
+  {
+    exitCode: 1,
+    stderr: { includes: 'Error: No assertions were tested during the run' }
+  }
 )

--- a/test/fail-when-no-assertions.mjs
+++ b/test/fail-when-no-assertions.mjs
@@ -1,0 +1,22 @@
+import { tester } from './helpers/index.js'
+
+await tester('fails on a test without any assertions',
+  function (t) {
+  },
+  `
+TAP version 13
+
+# fails on a test without any assertions
+not ok 1 - fails on a test without any assertions # time = 1.300587ms
+      ---
+      No assertions were tested
+      ...
+
+1..1
+# tests = 0/1 pass
+# asserts = 0/0 pass
+# time = 17.131802ms
+
+# not ok  `,
+  { exitCode: 1, stderr: '' }
+)

--- a/test/fail-when-no-assertions.mjs
+++ b/test/fail-when-no-assertions.mjs
@@ -20,6 +20,6 @@ not ok 1 - fails on a test without any assertions # time = 1.300587ms
 # not ok  `,
   {
     exitCode: 1,
-    stderr: { includes: 'Error: No assertions were tested during the run' }
+    stderr: ''
   }
 )

--- a/test/fail-when-no-assertions.mjs
+++ b/test/fail-when-no-assertions.mjs
@@ -9,7 +9,7 @@ TAP version 13
 # fails on a test without any assertions
 not ok 1 - fails on a test without any assertions # time = 1.300587ms
       ---
-      No assertions were tested
+      No assertions were called
       ...
 
 1..1


### PR DESCRIPTION
Currently a test can pass if it does not contain any assertions, as can an entire test run. I think that always indicates a bug in the tests.

The behaviour of this PR is:
- If a test contains 0 assertions, that test fails
- <strike>If an entire run contains 0 assertions, an error is thrown</strike>

<strike>Note: I couldn't find a clean way in the test-run lifetime to just make the run fail if there were 0 assertions, as this is known only when the `_onend` handler runs, so after the run finished already. That's why it explicitly throws an error there. (The main edge case is a run without any tests)</strike>

