### PR TITLE
Fix flags set with the BRITTLE env var

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -7,7 +7,7 @@ const { spawn } = require('child_process')
 const process = require('process')
 const TracingPromise = require('./lib/tracing-promise')
 
-const args = process.argv.slice(2).concat((process.env.BRITTLE || '').split(/\s|,/g).map(s => s.trim()).filter(s => s))
+const args = (process.env.BRITTLE || '').split(/\s|,/g).map(s => s.trim()).filter(s => s).concat(process.argv.slice(2))
 const cmd = command('brittle',
   flag('--solo, -s', 'Engage solo mode'),
   flag('--bail, -b', 'Bail out on first assert failure'),


### PR DESCRIPTION
Currently it's not supported to call `BRITTLE='--timeout 60000', because that gets transformed into args `['test/all.js',  '--timeout', '120000 ]`, causing brittle to try to run the tests at location `120000`.

This fix causes the args to become `[ '--timeout', '120000', 'test/all.js' ]`, which works as expected.
