### PR TITLE
Add `solo` and `skip` options to subtests

### DIFF
--- a/test/nesting-skip.mjs
+++ b/test/nesting-skip.mjs
@@ -1,0 +1,46 @@
+import { spawner } from './helpers/index.js'
+
+await spawner(
+  async function (test) {
+    test.test('subtest #1', function (child) {
+      child.pass()
+    })
+
+    test.test('subtest #2', { skip: true }, function (child) {
+      child.pass()
+    })
+
+    test.test.skip('subtest #3', function (child) {
+      child.pass()
+    })
+
+    test.test('subtest #4', function (child) {
+      child.pass()
+    })
+  },
+  `
+  TAP version 13
+
+  # subtest #1
+      ok 1 - passed
+  ok 1 - subtest #1 # time = 0.213333ms
+
+  # subtest #2
+  ok 2 - subtest #2 # SKIP
+
+  # subtest #3
+  ok 3 - subtest #3 # SKIP
+
+  # subtest #4
+      ok 1 - passed
+  ok 4 - subtest #4 # time = 0.025458ms
+
+  1..4
+  # tests = 4/4 pass
+  # asserts = 2/2 pass
+  # time = 2.997542ms
+
+  # ok
+  `,
+  { exitCode: 0, stderr: '' }
+)

--- a/test/nesting-solo.mjs
+++ b/test/nesting-solo.mjs
@@ -1,0 +1,48 @@
+import { spawner } from './helpers/index.js'
+
+await spawner(
+  async function (test) {
+    test.test('subtest #1', function (child) {
+      child.pass()
+    })
+
+    test.test('subtest #2', function (child) {
+      child.pass()
+    })
+
+    test.test('subtest #3', { solo: true }, function (child) {
+      child.pass()
+    })
+
+    test.test('subtest #4', function (child) {
+      child.pass()
+    })
+
+    test.test('subtest #5', function (child) {
+      child.pass()
+    })
+
+    test.test.solo('subtest #6', function (child) {
+      child.pass()
+    })
+  },
+  `
+  TAP version 13
+
+  # subtest #3
+      ok 1 - passed
+  ok 1 - subtest #3 # time = 0.207542ms
+
+  # subtest #6
+      ok 1 - passed
+  ok 2 - subtest #3 # time = 0.207542ms
+
+  1..2
+  # tests = 2/2 pass
+  # asserts = 2/2 pass
+  # time = 2.933333ms
+
+  # ok
+  `,
+  { exitCode: 0, stderr: '' }
+)


### PR DESCRIPTION
Attempt to solve: https://github.com/holepunchto/brittle/issues/39

---

The PR adds a side-effect as

```js
test((t) => {
  t.pass('#1')
  t.test((t) => t.pass('#2'))
  t.pass('#3')
})
```

produces:

```
TAP version 13

# test
    ok 1 - #1
    ok 2 - #3 // <-- WRONG ORDER
    ok 3 - #2
ok 1 -  # time = 0ms

1..1
# tests = 1/1 pass
# asserts = 3/3 pass
# time = 0ms

# ok
```

That is, subtests assertions are getting executed after non-subtests assertions. The cause is the `await wait()` needed for make possible `test.solos` getting filled out.