### PR TITLE
Install bare-process and update imports map

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -70,6 +70,9 @@ function explain (ok, message, assert, stackStartFunction, actual, expected, top
     delete info.actual
     delete info.expected
   }
+
+  if (info.diff) delete info.diff
+
   return info
 }
 

--- a/package.json
+++ b/package.json
@@ -45,25 +45,32 @@
   },
   "imports": {
     "assert": {
-      "bare": "bare-assert"
+      "bare": "bare-assert",
+      "default": "assert"
     },
     "child_process": {
-      "bare": "bare-subprocess"
+      "bare": "bare-subprocess",
+      "default": "child_process"
     },
     "fs": {
-      "bare": "bare-fs"
+      "bare": "bare-fs",
+      "default": "fs"
     },
     "os": {
-      "bare": "bare-os"
+      "bare": "bare-os",
+      "default": "os"
     },
     "path": {
-      "bare": "bare-path"
+      "bare": "bare-path",
+      "default": "path"
     },
     "process": {
-      "bare": "bare-process"
+      "bare": "bare-process",
+      "default": "process"
     },
     "url": {
-      "bare": "bare-url"
+      "bare": "bare-url",
+      "default": "url"
     }
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "bare-fs": "^4.1.6",
     "bare-os": "^3.6.1",
     "bare-path": "^3.0.0",
+    "bare-process": "^4.2.1",
     "bare-subprocess": "^5.0.0",
     "bare-url": "^2.1.6",
     "error-stack-parser": "^2.1.4",
@@ -57,6 +58,9 @@
     },
     "path": {
       "bare": "bare-path"
+    },
+    "process": {
+      "bare": "bare-process"
     },
     "url": {
       "bare": "bare-url"


### PR DESCRIPTION
support `process.env.BRITTLE` at

https://github.com/holepunchto/brittle/blob/82042fe0c22d3da856225c057af60bc12c7bb871/cmd.js#L10

test passed in local, but failed in CI
<img width="568" height="110" alt="image" src="https://github.com/user-attachments/assets/12f4e1c1-97a8-48f1-bcf7-b9a5c96c303c" />
