### PR TITLE
Support beforeEach and afterEach

### DIFF
--- a/index.js
+++ b/index.js
@@ -814,7 +814,7 @@ class Test {
   }
 
   async _runAfterEach () {
-    if (!this._beforeEachs.length) return
+    if (!this._afterEachs.length) return
 
     let fired = false
 

--- a/test/after-each.mjs
+++ b/test/after-each.mjs
@@ -1,0 +1,44 @@
+import { tester } from './helpers/index.js'
+
+await tester(
+  'afterEach classic',
+  async function (t) {
+    t.test(async function describe (t) {
+      t.afterEach(async function () {
+        console.log('[spawner tester] afterEach classic is called')
+        await new Promise((resolve) => {
+          setTimeout(resolve, 200)
+        })
+        console.log('[spawner tester] afterEach classic successful')
+      })
+
+      t.test(async (t) => {
+        t.pass()
+
+        await new Promise((resolve) => {
+          setTimeout(resolve, 10)
+        })
+
+        console.log('[spawner tester] end of test function')
+      })
+    })
+  },
+  `
+  TAP version 13
+
+  # afterEach classic
+      ok 1 - passed
+  [spawner tester] end of test function
+  [spawner tester] afterEach classic is called
+  [spawner tester] afterEach classic successful
+  ok 1 - afterEach classic # time = 214.155625ms
+
+  1..1
+  # tests = 1/1 pass
+  # asserts = 1/1 pass
+  # time = 217.490625ms
+
+  # ok
+  `,
+  { exitCode: 0, stderr: '' }
+)

--- a/test/before-each.mjs
+++ b/test/before-each.mjs
@@ -1,0 +1,44 @@
+import { tester } from './helpers/index.js'
+
+await tester(
+  'beforeEach classic',
+  async function (t) {
+    t.test(async function describe (t) {
+      t.beforeEach(async function () {
+        console.log('[spawner tester] beforeEach classic is called')
+        await new Promise((resolve) => {
+          setTimeout(resolve, 200)
+        })
+        console.log('[spawner tester] beforeEach classic successful')
+      })
+
+      t.test(async (t) => {
+        t.pass()
+
+        await new Promise((resolve) => {
+          setTimeout(resolve, 10)
+        })
+
+        console.log('[spawner tester] end of test function')
+      })
+    })
+  },
+  `
+  TAP version 13
+
+  # beforeEach classic
+  [spawner tester] beforeEach classic is called
+  [spawner tester] beforeEach classic successful
+      ok 1 - passed
+  [spawner tester] end of test function
+  ok 1 - beforeEach classic # time = 214.155625ms
+
+  1..1
+  # tests = 1/1 pass
+  # asserts = 1/1 pass
+  # time = 217.490625ms
+
+  # ok
+  `,
+  { exitCode: 0, stderr: '' }
+)

--- a/test/describe.mjs
+++ b/test/describe.mjs
@@ -1,0 +1,5 @@
+import { tester, spawner } from "./helpers/index.js";
+
+await tester("describe classic", async function (t) {
+  t.describe;
+});

--- a/test/describe.mjs
+++ b/test/describe.mjs
@@ -1,5 +1,0 @@
-import { tester, spawner } from "./helpers/index.js";
-
-await tester("describe classic", async function (t) {
-  t.describe;
-});


### PR DESCRIPTION
# Introduction

`beforeEach` and `afterEach` are quite popular in multiple testing frameworks (i.e. Jest, Mocha, Vitest), however, they are absent in brittle. This PR is to support `beforeEach` and `afterEach` in the next version.

# Implementation

Because brittle relied all tests on a atomic block named `test`, it lacks `describe` Block, which is to define `beforeEach` and `afterEach` in. In details, `describe` blocks allow users to add `beforeEach` and `afterEach` and won't run the ancestor's `beforeEach` and `afterEach`.

To distinguish `test` and `describe`, however, still respect the fundamental of atomic `test` block, we utilize the callback function name to determine a `describe` block.

## Usage

```js
t.test("this is a describe block", async function describe( t ) {
  t.beforeEach(async function () {
    // Before each
  })

  t.afterEach(async function () {
    // After each
  })

  t.test("this is a test block", async function ( t ) {
    t.pass()
  })
})
```
